### PR TITLE
Fix missing quick edit links

### DIFF
--- a/classes/class-utmdotcodes.php
+++ b/classes/class-utmdotcodes.php
@@ -50,9 +50,10 @@ class UtmDotCodes {
 		add_filter( 'wp_insert_post_data', [ &$this, 'insert_post_data' ], 10, 2 );
 		add_filter( 'gettext', [ &$this, 'change_publish_button' ], 10, 2 );
 
-		$is_post_list = ( 'edit.php' === $pagenow );
+		$is_post_list  = ( 'edit.php' === $pagenow );
+		$is_utmdc_post = ( 'utmdclink' === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ) );
 
-		if ( ( is_admin() && $is_post_list ) || $this->is_test() ) {
+		if ( ( is_admin() && $is_post_list && $is_utmdc_post ) || $this->is_test() ) {
 			add_action( 'restrict_manage_posts', [ &$this, 'filter_ui' ], 5, 1 );
 			add_action( 'pre_get_posts', [ &$this, 'apply_filters' ], 5, 1 );
 			add_filter( 'manage_' . self::POST_TYPE . '_posts_columns', [ &$this, 'post_list_header' ], 10, 1 );


### PR DESCRIPTION
# Description

This fixes the scope of how the admin edit interface is modified, in the same way as how the publish button is currently modified.

Fixes #35 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] TestUtmDotCodesActivation
- [x] TestUtmDotCodesAjax
- [x] TestUtmDotCodesIntegration
- [x] TestUtmDotCodesShortenBitly
- [x] TestUtmDotCodesShortenRebrandly
- [x] TestUtmDotCodesUnit

**Test Configuration**:

- **WordPress version**: 5.2.3
- **PHP version**: 7.3.6
- **MySQL version**: 10.3.15-MariaDB

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I had fun writing this code
